### PR TITLE
Add compatibility for patch 6.1

### DIFF
--- a/DeepDungeonDex.csproj
+++ b/DeepDungeonDex.csproj
@@ -49,7 +49,6 @@
 
   <ItemGroup>
     <PackageReference Include="DalamudPackager" Version="2.1.5" />
-    <PackageReference Include="ImGui.NET" Version="1.78.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DeepDungeonDex.json
+++ b/DeepDungeonDex.json
@@ -8,6 +8,6 @@
   "AssemblyVersion": "1.2.0.0",
   "RepoUrl": "https://github.com/Strati/DeepDungeonDex",
   "ApplicableVersion": "any",
-  "DalamudApiLevel": 5,
+  "DalamudApiLevel": 6,
   "LoadPriority": 0
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -95,8 +95,6 @@ namespace DeepDungeonDex
             this.pluginInterface.UiBuilder.Draw -= this.cui.Draw;
 
             this._framework.Update -= this.GetData;
-
-            this.pluginInterface.Dispose();
         }
 
         public void Dispose()


### PR DESCRIPTION
Hello, thanks for your work on this great plugin. I wanted to use it for patch 6.1, so I had to make the following changes to get it to build and load:

- Remove a pluginInterface.Dispose() call from Plugins.cs, since this was causing a build error (_'DalamudPluginInterface.Dispose()' is obsolete: 'Do not dispose "DalamudPluginInterface"_).
- Remove the PackageReference for ImGui.NET, because this was causing an error in dalamud.log when loading the plugin. I'm guessing the PackageReference isn't needed, because there's already another reference pointing to $(AppData)\XIVLauncher\addon\Hooks\dev\ImGui.NET.dll.
- Update the .json to show DalamudApiLevel of 6.

I tested these changes locally by running a 21-30 set, and had no issues.